### PR TITLE
Refactor & Star Lighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,14 @@ export function App() {
         sortByRef.current = sortBy;
     };
 
+    const [starLightState, setStarLightState] = useState<boolean>(false);
+    const starLightRef = useRef<boolean>(false);
+    const updateStarLight = (starLight: boolean) => {
+        setStarLightState(starLight);
+        starLightRef.current = starLight;
+    };
+
+
     // Toggle to reset the simulation
     const resetSim = useRef<boolean>(false);
 
@@ -74,7 +82,6 @@ export function App() {
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
     const [leaderboardShown, setLeaderboardShown] = useState<boolean>(false);
     const [settingsMenuShown, setSettingsMenuShown] = useState<boolean>(false);
-
     return (
         <body>
             <SimScreen>
@@ -88,6 +95,7 @@ export function App() {
                     resetSim={resetSim}
                     pausedRef={pausedRef}
                     sortByRef={sortByRef}
+                    starLightRef={starLightRef}
                 />
             </SimScreen>
             <Backdrop>
@@ -113,6 +121,8 @@ export function App() {
                     setLeaderboardShown={setLeaderboardShown}
                     settingsMenuShown={settingsMenuShown}
                     setSettingsMenuShown={setSettingsMenuShown}
+                    starLightState={starLightState}
+                    updateStarLight={updateStarLight}
                 />
                 {settingsMenuShown ? (
                     <SettingsMenu/>

--- a/src/assets/shaders/lightGlobal.frag.glsl
+++ b/src/assets/shaders/lightGlobal.frag.glsl
@@ -13,10 +13,10 @@ void main(void) {
     highp vec3 normal = normalize(vTransformedNormal);
     highp float directional = max(dot(normal, directionalVector), 0.0);
 
-    if (uIsStar > 0) {
-        ambientLight = vec3(1.0, 1.0, 1.0);
-        directionalLightColor = vec3(0.2, 0.2, 0.2);
-    }
+    // if (uIsStar > 0) {
+    //     ambientLight = vec3(1.0, 1.0, 1.0);
+    //     directionalLightColor = vec3(0.2, 0.2, 0.2);
+    // }
 
     highp vec3 lighting = ambientLight + (directionalLightColor * directional);
     gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);

--- a/src/assets/shaders/lightGlobal.frag.glsl
+++ b/src/assets/shaders/lightGlobal.frag.glsl
@@ -1,6 +1,7 @@
 // Flat-shaded with monodirectional light travelling with the camera
 
 uniform highp vec4 uFragColor;
+uniform highp int uIsStar;
 
 varying highp vec3 vTransformedNormal;
 
@@ -11,6 +12,11 @@ void main(void) {
 
     highp vec3 normal = normalize(vTransformedNormal);
     highp float directional = max(dot(normal, directionalVector), 0.0);
+
+    if (uIsStar > 0) {
+        ambientLight = vec3(1.0, 1.0, 1.0);
+        directionalLightColor = vec3(0.2, 0.2, 0.2);
+    }
 
     highp vec3 lighting = ambientLight + (directionalLightColor * directional);
     gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);

--- a/src/assets/shaders/lightGlobal.vert.glsl
+++ b/src/assets/shaders/lightGlobal.vert.glsl
@@ -13,6 +13,6 @@ varying highp vec4 vPosition;
 
 void main(void) {
     gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
-    vTransformedNormal = mat3(uNormalMatrix) * aVertexNormal;
+    vTransformedNormal = mat3(uNormalMatrix) * aVertexNormal; // Multiplying vertex normal by normal matrix causes light to rotate with camera
     vPosition = uModelViewMatrix * aVertexPosition;
 }

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -12,11 +12,22 @@ uniform highp int uIsStar;
 void main(void) {
     highp vec3 ambientLight = vec3(0.3, 0.3, 0.3);
     highp vec3 directionalLightColor = vec3(1, 1, 1);
+
+    //highp vec3 directionalVector = normalize(vec3(0.85, 0.8, 0.75));
     highp vec3 directionalVector = normalize(vec3(0.85, 0.8, 0.75));
+    if (uNumStars > 0) {
+        directionalVector = normalize(uStarLocations[0] - vPosition.xyz);
+    }
+
+    if (uIsStar > 0) {
+        ambientLight = vec3(0.7, 0.7, 0.7);
+        directionalLightColor = vec3(0, 0, 0);
+    }
+
+
 
     highp vec3 normal = normalize(vTransformedNormal);
     highp float directional = max(dot(normal, directionalVector), 0.0);
-
     highp vec3 lighting = ambientLight + (directionalLightColor * directional);
     gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);
 }

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -12,7 +12,7 @@ uniform highp vec3 uStarLocations[MAX_STARS];
 uniform highp int uIsStar;
 
 void main(void) {
-    highp vec3 ambient = vec3(0.3, 0.3, 0.3);
+    highp vec3 ambient = vec3(0.05, 0.05, 0.05);
     
     highp vec3 normal = normalize(vNormal);
 
@@ -21,9 +21,24 @@ void main(void) {
     highp vec3 diffuse = vec3(0, 0, 0);
 
     if (uNumStars > 0) {
+        // Calculate the direction to the largest star
         directionalVector = normalize(uStarLocations[0] - vFragPosition);
         highp float diff = max(dot(normal, directionalVector), 0.0);
-        diffuse = diff * uFragColor.rgb;
+
+        // Calculate the distance
+        highp float dist = distance(uStarLocations[0], vFragPosition);
+
+        // Light should linearly attenuate from 100% to 0%, falling off to 0 at 50au
+        // According to graphing calculator, y = -x/50 + 1 is the formula
+        // (This has no basis in physics, but may produce decent-looking results)
+        highp float attenuation_factor = ((-1.0 * dist) / 50.0) + 1.0;
+        
+        diffuse = diff * uFragColor.rgb * attenuation_factor;
+    }
+
+    if (uIsStar > 0) {
+        ambient = vec3(1.5, 1.5, 1.5);
+        diffuse = vec3(0.0, 0.0, 0.0);
     }
 
 

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -20,7 +20,29 @@ void main(void) {
     highp vec3 directionalVector = normalize(vec3(0, 0, -1));
     highp vec3 diffuse = vec3(0, 0, 0);
 
+    for (int i = 0; i < MAX_STARS; i++) {
+        if (i >= uNumStars) {
+            break;
+        }
+        // Calculate the direction to the largest star
+        directionalVector = normalize(uStarLocations[i] - vFragPosition);
+        highp float diff = max(dot(normal, directionalVector), 0.0);
+
+        // Calculate the distance
+        highp float dist = distance(uStarLocations[i], vFragPosition);
+
+        // Light should linearly attenuate from 100% to 0%, falling off to 0 at 50au
+        // According to graphing calculator, y = -x/50 + 1 is the formula
+        // (This has no basis in physics, but may produce decent-looking results)
+        highp float attenuation_factor = ((-1.0 * dist) / 50.0) + 1.0;
+        
+        diffuse += diff * uFragColor.rgb * attenuation_factor;
+    }
+    
+    /*
+    // Light calculated only from single-most-massive star
     if (uNumStars > 0) {
+
         // Calculate the direction to the largest star
         directionalVector = normalize(uStarLocations[0] - vFragPosition);
         highp float diff = max(dot(normal, directionalVector), 0.0);
@@ -33,8 +55,9 @@ void main(void) {
         // (This has no basis in physics, but may produce decent-looking results)
         highp float attenuation_factor = ((-1.0 * dist) / 50.0) + 1.0;
         
-        diffuse = diff * uFragColor.rgb * attenuation_factor;
+        diffuse += diff * uFragColor.rgb * attenuation_factor;
     }
+    */
 
     if (uIsStar > 0) {
         ambient = vec3(1.5, 1.5, 1.5);

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -1,0 +1,36 @@
+// Flat-shaded with monodirectional light travelling with the camera
+#define MAX_STARS 1000
+
+uniform highp vec4 uFragColor;
+varying highp vec3 vTransformedNormal;
+varying highp vec4 vPosition;
+
+uniform highp int uNumStars;
+uniform highp vec3 uStarLocations[MAX_STARS];
+uniform highp int uIsStar;
+
+void main(void) {
+    highp vec3 ambientLight = vec3(0.3, 0.3, 0.3);
+
+    if (uIsStar == 1) {
+        ambientLight = vec3(1.0, 1.0, 1.0); // No ambient light for stars
+    }
+    highp vec3 normal = normalize(vTransformedNormal);
+    highp vec3 lighting = ambientLight;
+
+    // Iterate through the stars and calculate their contribution
+    if (uIsStar == 0) {
+        for (int i = 0; i < MAX_STARS; i++) {
+            if (i >= uNumStars) break;
+
+            highp vec3 starDirection = normalize(uStarLocations[i] - vPosition.xyz);
+            highp float starIntensity = max(dot(normal, starDirection), 0.0);
+
+            // Add the star's contribution to the lighting
+            lighting += vec3(1.0, 1.0, 1.0) * starIntensity; // Assuming white light for stars
+        }
+    }
+    
+
+    gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);
+}

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -11,26 +11,12 @@ uniform highp int uIsStar;
 
 void main(void) {
     highp vec3 ambientLight = vec3(0.3, 0.3, 0.3);
+    highp vec3 directionalLightColor = vec3(1, 1, 1);
+    highp vec3 directionalVector = normalize(vec3(0.85, 0.8, 0.75));
 
-    if (uIsStar == 1) {
-        ambientLight = vec3(1.0, 1.0, 1.0); // No ambient light for stars
-    }
     highp vec3 normal = normalize(vTransformedNormal);
-    highp vec3 lighting = ambientLight;
+    highp float directional = max(dot(normal, directionalVector), 0.0);
 
-    // Iterate through the stars and calculate their contribution
-    if (uIsStar == 0) {
-        for (int i = 0; i < MAX_STARS; i++) {
-            if (i >= uNumStars) break;
-
-            highp vec3 starDirection = normalize(uStarLocations[i] - vPosition.xyz);
-            highp float starIntensity = max(dot(normal, starDirection), 0.0);
-
-            // Add the star's contribution to the lighting
-            lighting += vec3(1.0, 1.0, 1.0) * starIntensity; // Assuming white light for stars
-        }
-    }
-    
-
+    highp vec3 lighting = ambientLight + (directionalLightColor * directional);
     gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);
 }

--- a/src/assets/shaders/lightStars.frag.glsl
+++ b/src/assets/shaders/lightStars.frag.glsl
@@ -2,32 +2,32 @@
 #define MAX_STARS 1000
 
 uniform highp vec4 uFragColor;
-varying highp vec3 vTransformedNormal;
-varying highp vec4 vPosition;
+varying highp vec3 vNormal;
+
+
+varying highp vec3 vFragPosition;
 
 uniform highp int uNumStars;
 uniform highp vec3 uStarLocations[MAX_STARS];
 uniform highp int uIsStar;
 
 void main(void) {
-    highp vec3 ambientLight = vec3(0.3, 0.3, 0.3);
-    highp vec3 directionalLightColor = vec3(1, 1, 1);
+    highp vec3 ambient = vec3(0.3, 0.3, 0.3);
+    
+    highp vec3 normal = normalize(vNormal);
 
     //highp vec3 directionalVector = normalize(vec3(0.85, 0.8, 0.75));
-    highp vec3 directionalVector = normalize(vec3(0.85, 0.8, 0.75));
+    highp vec3 directionalVector = normalize(vec3(0, 0, -1));
+    highp vec3 diffuse = vec3(0, 0, 0);
+
     if (uNumStars > 0) {
-        directionalVector = normalize(uStarLocations[0] - vPosition.xyz);
-    }
-
-    if (uIsStar > 0) {
-        ambientLight = vec3(0.7, 0.7, 0.7);
-        directionalLightColor = vec3(0, 0, 0);
+        directionalVector = normalize(uStarLocations[0] - vFragPosition);
+        highp float diff = max(dot(normal, directionalVector), 0.0);
+        diffuse = diff * uFragColor.rgb;
     }
 
 
 
-    highp vec3 normal = normalize(vTransformedNormal);
-    highp float directional = max(dot(normal, directionalVector), 0.0);
-    highp vec3 lighting = ambientLight + (directionalLightColor * directional);
-    gl_FragColor = vec4(uFragColor.rgb * lighting, uFragColor.a);
+    highp vec3 result = (ambient + diffuse) * uFragColor.rgb;
+    gl_FragColor = vec4(result, uFragColor.a);
 }

--- a/src/assets/shaders/lightStars.vert.glsl
+++ b/src/assets/shaders/lightStars.vert.glsl
@@ -5,14 +5,17 @@ attribute vec3 aVertexNormal;
 attribute vec4 aVertexColor;
 
 uniform mat4 uNormalMatrix;
+uniform mat4 uModelMatrix;
+uniform mat4 uViewMatrix;
 uniform mat4 uModelViewMatrix;
 uniform mat4 uProjectionMatrix;
 
-varying highp vec3 vTransformedNormal;
-varying highp vec4 vPosition;
+varying highp vec3 vNormal;
+varying highp vec3 vFragPosition;
 
 void main(void) {
     gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
-    vTransformedNormal = aVertexNormal;
-    vPosition = uModelViewMatrix * aVertexPosition;
+    vFragPosition = vec3(uModelMatrix * aVertexPosition);
+    vNormal = aVertexNormal;
+    
 }

--- a/src/assets/shaders/lightStars.vert.glsl
+++ b/src/assets/shaders/lightStars.vert.glsl
@@ -1,0 +1,18 @@
+// Directional lighting from some source (does not follow camera)
+
+attribute vec4 aVertexPosition;
+attribute vec3 aVertexNormal;
+attribute vec4 aVertexColor;
+
+uniform mat4 uNormalMatrix;
+uniform mat4 uModelViewMatrix;
+uniform mat4 uProjectionMatrix;
+
+varying highp vec3 vTransformedNormal;
+varying highp vec4 vPosition;
+
+void main(void) {
+    gl_Position = uProjectionMatrix * uModelViewMatrix * aVertexPosition;
+    vTransformedNormal = aVertexNormal;
+    vPosition = uModelViewMatrix * aVertexPosition;
+}

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -15,6 +15,8 @@ interface ControlButtonProps {
     setLeaderboardShown: (shouldShow: boolean) => void;
     settingsMenuShown: boolean;
     setSettingsMenuShown: (shouldShow: boolean) => void;
+    starLightState: boolean;
+    updateStarLight: (starLight: boolean) => void;
 }
 
 export function ControlButtons(props: ControlButtonProps) {
@@ -78,7 +80,9 @@ export function ControlButtons(props: ControlButtonProps) {
                 <ButtonRow>
                     <ControlButton
                         dim={'40px'}
-
+                        onClick={() => {
+                            props.updateStarLight(!props.starLightState);
+                        }}
                     >
                         <SunnyIcon color={"white"} dim={"40px"} filled={true} />
                     </ControlButton>

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -237,11 +237,11 @@ export function Sim(props: SimProps) {
                 // Create a view matrix for the camera
         
                 // Update the camera position to the current position of the followed body
-                if (universe.current.bodyFollowedRef.current !== -1) {
+                if (bodyFollowedRef.current !== -1) {
                     cameraRef.current.setTarget(
-                        universe.current.positionsX[universe.current.bodyFollowedRef.current],
-                        universe.current.positionsY[universe.current.bodyFollowedRef.current],
-                        universe.current.positionsZ[universe.current.bodyFollowedRef.current],
+                        universe.current.positionsX[bodyFollowedRef.current],
+                        universe.current.positionsY[bodyFollowedRef.current],
+                        universe.current.positionsZ[bodyFollowedRef.current],
                     );
                 }
                 const cameraMatrix = cameraRef.current.getViewMatrix();

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -93,6 +93,8 @@ export function Sim(props: SimProps) {
                 },
                 uniformLocations: {
                     projectionMatrix: gl.getUniformLocation(shaderProgram, "uProjectionMatrix"),
+                    modelMatrix: gl.getUniformLocation(shaderProgram, "uModelMatrix"),
+                    viewMatrix: gl.getUniformLocation(shaderProgram, "uViewMatrix"),
                     modelViewMatrix: gl.getUniformLocation(shaderProgram, "uModelViewMatrix"),
                     normalMatrix: gl.getUniformLocation(shaderProgram, "uNormalMatrix"),
                     uFragColor: gl.getUniformLocation(shaderProgram, "uFragColor"),
@@ -222,6 +224,8 @@ export function Sim(props: SimProps) {
                     mat4.transpose(normalMatrix, normalMatrix);
         
                     // Sets shader uniforms for model normals
+                    gl.uniformMatrix4fv(programInfo.uniformLocations.modelMatrix, false, modelMatrix);
+                    gl.uniformMatrix4fv(programInfo.uniformLocations.viewMatrix, false, cameraMatrix);
                     gl.uniformMatrix4fv(programInfo.uniformLocations.modelViewMatrix, false, modelViewMatrix);
                     gl.uniformMatrix4fv(programInfo.uniformLocations.normalMatrix, false, normalMatrix);
                     gl.uniform4fv(programInfo.uniformLocations.uFragColor, [
@@ -234,14 +238,8 @@ export function Sim(props: SimProps) {
 
                     // Gets each of the stars' locations for the purpose of creating a lighting shader
                     const starLocs: Array<vec3> = universe.current.getStarLocations();
-                    const transformedStarLocs: Array<vec3> = starLocs.map((star) => {
-                        const starVec4 = vec4.fromValues(star[0], star[1], star[2], 1.0); // Convert to vec4 for matrix multiplication
-                        const transformedStarVec4 = vec4.create();
-                        vec4.transformMat4(transformedStarVec4, starVec4, cameraMatrix); // Transform to view space
-                        return vec3.fromValues(transformedStarVec4[0], transformedStarVec4[1], transformedStarVec4[2]); // Convert back to vec3
-                    });
-                    const flattenedStarLocs = transformedStarLocs.flatMap((vec) => [vec[0], vec[1], vec[2]]);
-                    const numStars = transformedStarLocs.length;
+                    const flattenedStarLocs = starLocs.flatMap((vec) => [vec[0], vec[1], vec[2]]);
+                    const numStars = starLocs.length;
 
                     gl.uniform3fv(programInfo.uniformLocations.uStarLocations, flattenedStarLocs);
                     gl.uniform1i(programInfo.uniformLocations.uNumStars, numStars);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -33,6 +33,7 @@ interface SimProps {
     resetSim: React.RefObject<boolean>;
     pausedRef: React.RefObject<boolean>;
     sortByRef: React.RefObject<sortQuery>;
+    starLightRef: React.RefObject<boolean>;
 }
 
 export function Sim(props: SimProps) {
@@ -45,7 +46,8 @@ export function Sim(props: SimProps) {
         updateBodyFollowed,
         resetSim,
         pausedRef,
-        sortByRef
+        sortByRef,
+        starLightRef,
     } = props;
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const settings: UniverseSettings = {
@@ -87,6 +89,7 @@ export function Sim(props: SimProps) {
                 return;
             }
             const starlightShaderProgramInfo: ProgramInfo = {
+                name: "starlight",
                 program: starlightShaderProgram,
                 attribLocations: {
                     vertexPosition: gl.getAttribLocation(starlightShaderProgram, "aVertexPosition"),
@@ -113,6 +116,7 @@ export function Sim(props: SimProps) {
                 return;
             }
             const camlightProgramInfo: ProgramInfo = {
+                name: "camlight",
                 program: camlightShaderProgram,
                 attribLocations: {
                     vertexPosition: gl.getAttribLocation(camlightShaderProgram, "aVertexPosition"),
@@ -154,6 +158,12 @@ export function Sim(props: SimProps) {
                 const deltaTime = now - then;
                 then = now;
                 accumulatedTime += deltaTime;
+
+                if (starLightRef.current === true && programInfoRef.current?.name !== "starlight") {
+                    programInfoRef.current = starlightShaderProgramInfo;
+                } else if (starLightRef.current === false && programInfoRef.current?.name !== "camlight") {
+                    programInfoRef.current = camlightProgramInfo;
+                }
 
                 if (!programInfoRef.current) {
                     console.error("Program info not found");

--- a/src/hooks/useMouseControls.tsx
+++ b/src/hooks/useMouseControls.tsx
@@ -1,0 +1,52 @@
+import { useRef } from "react";
+import { Camera } from "../lib/webGL/camera";
+
+export function useMouseControls(cameraRef: React.RefObject<Camera>, cameraSensitivity: number) {
+    const isDragging = useRef(false);
+    const lastMousePosition = useRef<{ x: number; y: number } | null>(null);
+
+    const handleMouseWheel = (event: React.WheelEvent<HTMLCanvasElement>) => {
+        cameraRef.current!.zoom -= event.deltaY * 0.01;
+        cameraRef.current!.zoom = Math.min(Math.max(cameraRef.current!.zoom, -50), -5);
+    };
+
+    const handleMouseDown = (event: React.MouseEvent<HTMLCanvasElement>) => {
+        isDragging.current = true;
+        const rect = event.currentTarget.getBoundingClientRect();
+        lastMousePosition.current = {
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+        };
+    };
+
+    const handleMouseMove = (event: React.MouseEvent<HTMLCanvasElement>) => {
+        if (!isDragging.current || !lastMousePosition.current) return;
+
+        const rect = event.currentTarget.getBoundingClientRect();
+        const currentMousePosition = {
+            x: event.clientX - rect.left,
+            y: event.clientY - rect.top,
+        };
+
+        const deltaX = currentMousePosition.x - lastMousePosition.current.x;
+        const deltaY = currentMousePosition.y - lastMousePosition.current.y;
+
+        cameraRef.current!.yaw -= deltaX * cameraSensitivity;
+        cameraRef.current!.pitch -= deltaY * cameraSensitivity;
+
+        // Clamp pitch between -90 and 90
+        cameraRef.current!.pitch = Math.max(
+            Math.min(cameraRef.current!.pitch, Math.PI / 2 - 0.001),
+            -Math.PI / 2 + 0.001
+        );
+
+        lastMousePosition.current = currentMousePosition;
+    };
+
+    const handleMouseUp = () => {
+        isDragging.current = false;
+        lastMousePosition.current = null;
+    };
+
+    return { handleMouseWheel, handleMouseDown, handleMouseMove, handleMouseUp };
+}

--- a/src/hooks/useMouseControls.tsx
+++ b/src/hooks/useMouseControls.tsx
@@ -6,8 +6,10 @@ export function useMouseControls(cameraRef: React.RefObject<Camera>, cameraSensi
     const lastMousePosition = useRef<{ x: number; y: number } | null>(null);
 
     const handleMouseWheel = (event: React.WheelEvent<HTMLCanvasElement>) => {
+        const minZoom = 1;
+        const maxZoom = 50;
         cameraRef.current!.zoom -= event.deltaY * 0.01;
-        cameraRef.current!.zoom = Math.min(Math.max(cameraRef.current!.zoom, -50), -5);
+        cameraRef.current!.zoom = Math.min(Math.max(cameraRef.current!.zoom, -1*maxZoom), -1*minZoom);
     };
 
     const handleMouseDown = (event: React.MouseEvent<HTMLCanvasElement>) => {

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -40,9 +40,9 @@ export class Universe {
     public orbitalIndices: Float32Array;
     public orbitalDistances: Float32Array;
 
-    public bodyFollowedRef: React.RefObject<number>;
     public updateBodyFollowed: (newBodyFollowed: number) => void;
     private sortByRef: React.RefObject<sortQuery>;
+    private bodyFollowedRef: React.RefObject<number>;
 
     constructor(
         settings: UniverseSettings,

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -375,18 +375,21 @@ export class Universe {
     }
 
     public getStarLocations(): Array<vec3> {
-        const Stars = new Array<vec3>();
+        const Stars = new Array<{ pos: vec3; mass: number }>();
         for (let i = 0; i < this.settings.numBodies; i++) {
             if (!this.bodiesActive[i]) {
                 continue;
             }
             if (this.masses[i] >= this.settings.starThreshold) {
-                Stars.push(
-                    vec3.fromValues(this.positionsX[i], this.positionsY[i], this.positionsZ[i]),
-                );
+                Stars.push({
+                    pos: vec3.fromValues(this.positionsX[i], this.positionsY[i], this.positionsZ[i]),
+                    mass: this.masses[i]
+                });
             }
         }
-        return Stars;
+
+        Stars.sort((a, b) => b.mass - a.mass);
+        return Stars.map((star) => star.pos);
     }
 
     private getInitialAngularVelocity(x: number, y: number, z: number): { x: number; y: number; z: number } {

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -3,6 +3,7 @@ import { getRandomFloat } from "../../random/random";
 import React from "react";
 import { LeaderboardBody } from "../../components/leaderboard/LeaderboardBody";
 import { sortQuery } from "../defines/sortQuery";
+import { vec3 } from "gl-matrix";
 
 const G = 4 * Math.PI * Math.PI; // Gravitational constant
 
@@ -11,6 +12,7 @@ export interface UniverseSettings {
     timeStep: number;
     numBodies: number; // THe number of starting bodies in the universe
     size: number; // The size of the universe in astronomical units
+    starThreshold: number;
 }
 
 export class Universe {
@@ -366,6 +368,25 @@ export class Universe {
         });
 
         return massRankings;
+    }
+
+    public isStar(idx: number) {
+        return this.masses[idx] >= this.settings.starThreshold;
+    }
+
+    public getStarLocations(): Array<vec3> {
+        const Stars = new Array<vec3>();
+        for (let i = 0; i < this.settings.numBodies; i++) {
+            if (!this.bodiesActive[i]) {
+                continue;
+            }
+            if (this.masses[i] >= this.settings.starThreshold) {
+                Stars.push(
+                    vec3.fromValues(this.positionsX[i], this.positionsY[i], this.positionsZ[i]),
+                );
+            }
+        }
+        return Stars;
     }
 
     private getInitialAngularVelocity(x: number, y: number, z: number): { x: number; y: number; z: number } {

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -1,11 +1,7 @@
-import { mat4 } from "gl-matrix";
+
 import { getRandomFloat } from "../../random/random";
-import { Buffers } from "../webGL/buffers";
-import { ProgramInfo } from "../webGL/programInfo";
-import { setNormalAttribute, setPositionAttribute } from "../webGL/attributes";
 import React from "react";
 import { LeaderboardBody } from "../../components/leaderboard/LeaderboardBody";
-import { Camera } from "../webGL/camera";
 import { sortQuery } from "../defines/sortQuery";
 
 const G = 4 * Math.PI * Math.PI; // Gravitational constant

--- a/src/lib/webGL/programInfo.tsx
+++ b/src/lib/webGL/programInfo.tsx
@@ -1,4 +1,5 @@
 export interface ProgramInfo {
+    name: string;
     program: WebGLProgram;
     attribLocations: {
         vertexPosition: GLint;

--- a/src/lib/webGL/programInfo.tsx
+++ b/src/lib/webGL/programInfo.tsx
@@ -10,5 +10,8 @@ export interface ProgramInfo {
         modelViewMatrix: WebGLUniformLocation | null;
         normalMatrix: WebGLUniformLocation | null;
         uFragColor: WebGLUniformLocation | null;
+        uStarLocations: WebGLUniformLocation | null;
+        uNumStars: WebGLUniformLocation | null;
+        uIsStar: WebGLUniformLocation | null;
     };
 }

--- a/src/lib/webGL/programInfo.tsx
+++ b/src/lib/webGL/programInfo.tsx
@@ -7,6 +7,8 @@ export interface ProgramInfo {
     };
     uniformLocations: {
         projectionMatrix: WebGLUniformLocation | null;
+        modelMatrix: WebGLUniformLocation | null;
+        viewMatrix: WebGLUniformLocation | null;
         modelViewMatrix: WebGLUniformLocation | null;
         normalMatrix: WebGLUniformLocation | null;
         uFragColor: WebGLUniformLocation | null;

--- a/src/lib/webGL/shaders.tsx
+++ b/src/lib/webGL/shaders.tsx
@@ -1,7 +1,7 @@
 //
 // Initialize a shader program, so WebGL knows how to draw our data
 //
-export function initShaderProgram(gl: WebGLRenderingContext, vsSource: string, fsSource: string) {
+export function initShaderProgram(gl: WebGLRenderingContext, vsSource: string, fsSource: string): WebGLProgram | null {
     const vertexShader = loadShader(gl, gl.VERTEX_SHADER, vsSource);
     const fragmentShader = loadShader(gl, gl.FRAGMENT_SHADER, fsSource);
 
@@ -33,7 +33,7 @@ export function initShaderProgram(gl: WebGLRenderingContext, vsSource: string, f
 // creates a shader of the given type, uploads the source and
 // compiles it.
 //
-export function loadShader(gl: WebGLRenderingContext, type: GLenum, source: string) {
+export function loadShader(gl: WebGLRenderingContext, type: GLenum, source: string): WebGLProgram | null {
     const shader = gl.createShader(type);
 
     // Verify shader is not null


### PR DESCRIPTION
- All of the rendering / scene drawing logic has been removed from the universe class. It was starting to not make sense to keep both rendering and simulation logic bundled into one class. Instead, I decided to more closely mingle the rendering with the front-end React elements, and keep the universe simulation logic in its own separate class.

- I added more advanced scene lighting in the form of a "starlight" mode. Once stars reach above a threshold (0.8 solar masses in this case), they begin to light up orbiting bodies. The stars themselves are not lit by other stars - Instead, they have a high level of ambient lighting. Starlight linearly attenuates over distance, reaching 0% at 50 astronomical units (this is not in-line with how real light behaves, but it makes for neat results.) Star brightness is not yet affected by mass - This will be a later goal.