### PR TITLE
Procedural generation for gas giant and terrestrial shaders

### DIFF
--- a/docs/featureBits.md
+++ b/docs/featureBits.md
@@ -1,0 +1,2 @@
+## Gas Giant
+

--- a/src/assets/shaders/starlight/starlight.frag.glsl
+++ b/src/assets/shaders/starlight/starlight.frag.glsl
@@ -129,7 +129,6 @@ vec3 gasGiantColor() {
         // Odd band, use color2
         color = mix(color2, color1, smoothFactor);
     }
-    color=featureTexels[0].rgb;
     return color;
 }
 
@@ -244,11 +243,6 @@ void main(void) {
         planetColor = terrestrialColor(makeNoise(0.5, 0.15));
     }
     fragColor = vec4(result * planetColor, 1.0);
-
-    //fragColor = vec4(texColor, 1.0);
-
-    //fragColor = vec4(texture(uNoiseTex, vec3(vTexCoords, noiseTexSliceFloat)).rgb, 1.0);
-    fragColor = vec4(texture(uFeatureTex, vTexCoords).rgb, 1.0);
 
     if (uIsStar > 0) {
         ambient = vec3(1.5, 1.5, 1.5);

--- a/src/assets/shaders/starlight/starlight.frag.glsl
+++ b/src/assets/shaders/starlight/starlight.frag.glsl
@@ -22,7 +22,7 @@ uniform float uAngularVelocity;
 uniform float uRotationMultiplier;
 
 uniform lowp sampler2DArray uNoiseTex;
-uniform int uNoiseTexSlice;
+uniform int uPlanetID;
 
 // layout(std140, binding=0) buffer StarLights {
 //     vec3 uboStarLocations[MAX_STARS];
@@ -52,10 +52,13 @@ const float MATERIAL_SHINNINESS = 32.0;
 const float PI = 3.14159265358979323846;
 
 vec3 gasGiantColor() {
+    int noiseTexSlice = uPlanetID % 256;
+
     // Sphere tex coordinates
     int numBands = 9;
     float s = vTexCoords.s;
     float t = vTexCoords.t;
+    
 
     vec2 nTexCoords = vTexCoords;
     float nBandPosition = t * float(numBands);
@@ -77,9 +80,9 @@ vec3 gasGiantColor() {
 
     float amp = 0.08;
     float freq = 0.25;
-    float uNoiseTexSliceFloat = float(uNoiseTexSlice);
+    float noiseTexSliceFloat = float(noiseTexSlice);
     vec2 rotatedTexCoords = vTexCoords;
-    vec4 noiseTex = texture(uNoiseTex, freq*vec3(nTexCoords, uNoiseTexSliceFloat));
+    vec4 noiseTex = texture(uNoiseTex, freq*vec3(nTexCoords, noiseTexSliceFloat));
     float n = noiseTex.r + noiseTex.g + noiseTex.b + noiseTex.a;
     n = n - 2.0;
     n *= amp;
@@ -110,6 +113,7 @@ vec3 gasGiantColor() {
 }
 
 vec3 terrestrialColor(float n) {
+    int noiseTexSlice = uPlanetID % 256;
     const float diameterA = 0.1;
     const float diameterB = 0.1;
 
@@ -178,8 +182,9 @@ vec3 calculatePointLight(vec3 starLoc, vec3 normal, vec3 fragPos, vec3 viewDir) 
 }
 
 float makeNoise(float amp, float freq) {
-    float uNoiseTexSliceFloat = float(uNoiseTexSlice);
-    vec4 noiseTex = texture(uNoiseTex, freq*vec3(vTexCoords, uNoiseTexSliceFloat));
+    int noiseTexSlice = uPlanetID % 256;
+    float noiseTexSliceFloat = float(noiseTexSlice);
+    vec4 noiseTex = texture(uNoiseTex, freq*vec3(vTexCoords, noiseTexSliceFloat));
     float noise = noiseTex.r + noiseTex.g + noiseTex.b + noiseTex.a;
     noise = noise - 2.0;
     noise *= amp;
@@ -200,7 +205,6 @@ void main(void) {
         }
         result += calculatePointLight(uStarLocations[i], norm, vFragPosition, viewDir);
     }
-
 
 
     // Apply the result to the fragment color

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -874,6 +874,7 @@ export function Sim() {
 
                         gl.activeTexture(gl.TEXTURE1);
                         gl.bindTexture(gl.TEXTURE_2D, planetaryFeatureTexture);
+                        gl.activeTexture(gl.TEXTURE0);
                     } else {
                         // Bind Buffers
                         setPositionAttribute(gl, sphereBuffers, camlightProgramInfo.attribLocations);
@@ -1038,6 +1039,7 @@ export function Sim() {
                         Bloom Blur
                     */
                     if (starLightRef.current) {
+                        // Bind texture and use bloom texture
                         gl.useProgram(gaussianBlurProgramInfo.program);
                         setPositionAttribute2D(gl, quadBuffers, gaussianBlurProgramInfo.attribLocations);
                         setTexCoordAttribute(gl, quadBuffers, gaussianBlurProgramInfo.attribLocations);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -295,6 +295,7 @@ export function Sim() {
                     uNoiseTex: gl.getUniformLocation(starlightShaderProgram, "uNoiseTex"),
                     uFeatureTex: gl.getUniformLocation(starlightShaderProgram, "uFeatureTex"),
                     uPlanetID: gl.getUniformLocation(starlightShaderProgram, "uPlanetID"),
+                    uNumFeatureSampleTexels: gl.getUniformLocation(starlightShaderProgram, "uNumFeatureSampleTexels"),
                 },
             };
 
@@ -330,6 +331,14 @@ export function Sim() {
                 They will grab the bits from the r, g, b, a values
             */
             const planetaryFeatureTexture = gl.createTexture();
+            if (universe.current.planetFeatureTextureData.length != 64 * 64 * 4) {
+                console.error(
+                    "Planetary feature texture data is not the correct size. Expected 64x64x4, got: ",
+                    universe.current.planetFeatureTextureData.length,
+                );
+            } else {
+                console.log(universe.current.planetFeatureTextureData);
+            }
             gl.activeTexture(gl.TEXTURE1); // Activate texture unit 1
             gl.bindTexture(gl.TEXTURE_2D, planetaryFeatureTexture);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
@@ -345,8 +354,28 @@ export function Sim() {
                 0,
                 gl.RGBA,
                 gl.UNSIGNED_BYTE,
-                null, // Placeholder for planetary feature texture
+                universe.current.planetFeatureTextureData, // Placeholder for planetary feature texture
             );
+            console.log(
+                "First four: ",
+                universe.current.planetFeatureTextureData[0],
+                universe.current.planetFeatureTextureData[1],
+                universe.current.planetFeatureTextureData[2],
+                universe.current.planetFeatureTextureData[3],
+                "Last four: ",
+                universe.current.planetFeatureTextureData[universe.current.planetFeatureTextureData.length - 4],
+                universe.current.planetFeatureTextureData[universe.current.planetFeatureTextureData.length - 3],
+                universe.current.planetFeatureTextureData[universe.current.planetFeatureTextureData.length - 2],
+                universe.current.planetFeatureTextureData[universe.current.planetFeatureTextureData.length - 1],
+            );
+            // Bind uniform to starlight program
+            gl.uniform1i(starlightProgramInfo.uniformLocations.uFeatureTex, 1); // Texture unit 1
+            gl.uniform1i(starlightProgramInfo.uniformLocations.uNumFeatureSampleTexels, settings.numFeatureTexels);
+
+            console.log();
+
+            // Reactivate texture unit 0
+            gl.activeTexture(gl.TEXTURE0);
 
             // Initialize texture shader for simple texture quad
             const texQuadShaderProgram = initShaderProgram(gl, vertTexQuad, fragTexQuad);
@@ -842,6 +871,9 @@ export function Sim() {
                             starlightProgramInfo.uniformLocations.uRotationMultiplier,
                             settings.rotationMultiplier,
                         );
+
+                        gl.activeTexture(gl.TEXTURE1);
+                        gl.bindTexture(gl.TEXTURE_2D, planetaryFeatureTexture);
                     } else {
                         // Bind Buffers
                         setPositionAttribute(gl, sphereBuffers, camlightProgramInfo.attribLocations);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -293,7 +293,8 @@ export function Sim() {
                     uAngularVelocity: gl.getUniformLocation(starlightShaderProgram, "uAngularVelocity"),
                     uRotationMultiplier: gl.getUniformLocation(starlightShaderProgram, "uRotationMultiplier"),
                     uNoiseTex: gl.getUniformLocation(starlightShaderProgram, "uNoiseTex"),
-                    uNoiseTexSlice: gl.getUniformLocation(starlightShaderProgram, "uNoiseTexSlice"),
+                    uFeatureTex: gl.getUniformLocation(starlightShaderProgram, "uFeatureTex"),
+                    uPlanetID: gl.getUniformLocation(starlightShaderProgram, "uPlanetID"),
                 },
             };
 
@@ -323,6 +324,29 @@ export function Sim() {
             // Bind uniform to starlight program
             gl.useProgram(starlightProgramInfo.program);
             gl.uniform1i(starlightProgramInfo.uniformLocations.uNoiseTex, 0); // Texture unit 0
+
+            /*
+                Each planet will sample from a number of texels of the planetary feature texture
+                They will grab the bits from the r, g, b, a values
+            */
+            const planetaryFeatureTexture = gl.createTexture();
+            gl.activeTexture(gl.TEXTURE1); // Activate texture unit 1
+            gl.bindTexture(gl.TEXTURE_2D, planetaryFeatureTexture);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+            gl.texImage2D(
+                gl.TEXTURE_2D,
+                0,
+                gl.RGBA,
+                64, // width
+                64, // height
+                0,
+                gl.RGBA,
+                gl.UNSIGNED_BYTE,
+                null, // Placeholder for planetary feature texture
+            );
 
             // Initialize texture shader for simple texture quad
             const texQuadShaderProgram = initShaderProgram(gl, vertTexQuad, fragTexQuad);
@@ -905,7 +929,7 @@ export function Sim() {
                             );
 
                             const noiseSlice = i % maxLayers;
-                            gl.uniform1i(starlightProgramInfo.uniformLocations.uNoiseTexSlice, noiseSlice); // Texture unit 0
+                            gl.uniform1i(starlightProgramInfo.uniformLocations.uPlanetID, noiseSlice); // Texture unit 0
 
                             gl.uniform1f(
                                 starlightProgramInfo.uniformLocations.uAngularVelocity,

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -6,7 +6,7 @@ import { MassThresholds } from "../defines/physics";
 import { RngState } from "../../random/RngState";
 import { removeFromArray } from "../ds/arrays";
 
-const G = 4 * Math.PI * Math.PI; // Gravitational constant
+const G = 4 * Math.PI * Math.PI; // Gravitational constant for 1yr, 1AU, 1 solar mass
 
 export class Universe {
     public settings: UniverseSettings;
@@ -14,6 +14,7 @@ export class Universe {
 
     // Uint8Array and Float32Array are guaranteed to be contiguous in memory, which makes them more performant (cache locality).
     public bodiesActive: Uint8Array;
+
     public positionsX: Float32Array;
     public positionsY: Float32Array;
     public positionsZ: Float32Array;
@@ -39,6 +40,8 @@ export class Universe {
     public temperatures: Float32Array;
     public timeElapsed: number;
     public centerStar: number | null;
+    public numFeatureChannels: number;
+    public planetFeatureTextureData: Uint8Array; // Placeholder for planet feature texture data
 
     constructor(settings: UniverseSettings) {
         this.settings = settings;
@@ -79,6 +82,9 @@ export class Universe {
         this.numActive = this.settings.numBodies;
         this.timeElapsed = 0;
         this.centerStar = null;
+
+        this.numFeatureChannels = 4;
+        this.planetFeatureTextureData = new Uint8Array(this.settings.numBodies * 4 * this.numFeatureChannels);
 
         this.initialize();
     }
@@ -188,6 +194,8 @@ export class Universe {
             const meanTilt = this.settings.axialTiltMean;
             const stdDev = this.settings.axialTiltStdev;
             this.axialTilts[i] = this.rng.getGaussianF32(meanTilt, stdDev); // Axial tilt in radians
+
+            this.setPlanetaryFeatureData();
         }
 
         // Set star in center if applicable
@@ -260,6 +268,10 @@ export class Universe {
         this.numSattelites.fill(0);
         this.timeElapsed = 0;
         this.centerStar = null;
+        this.stars.fill(-1);
+        this.numStars = 0;
+        this.temperatures.fill(0);
+        this.planetFeatureTextureData.fill(0);
     }
 
     public reset(): void {
@@ -800,6 +812,21 @@ export class Universe {
         const U = G * (this.masses[bodyA] + this.masses[bodyB]);
 
         return 0.5 * v * v - U / r;
+    }
+
+    private setPlanetaryFeatureData() {
+        /**
+         * Sets the planetary feature texture data.
+         * This is a placeholder for now, but can be used to set the texture data for each planet.
+         */
+        for (let i = 0; i < this.settings.numBodies; i++) {
+            for (let j = 0; j < this.numFeatureChannels; j++) {
+                const idx = i * this.numFeatureChannels + j;
+                // Set the data for each planet
+                // For now, we will just set the data to a random value between 0 and 1
+                this.planetFeatureTextureData[idx] = this.rng.getRandomU8();
+            }
+        }
     }
 
     /*

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -125,7 +125,7 @@ export class Universe {
         this.centerStar = null;
 
         // Num bodies times number of texels time 4 (RGBA channels)
-        this.planetFeatureTextureData = new Uint8Array(this.settings.numBodies * 4 * this.settings.numFeatureTexels);
+        this.planetFeatureTextureData = new Uint8Array(64 * 64 * 4);
 
         this.initialize();
     }
@@ -860,13 +860,8 @@ export class Universe {
          * Sets the planetary feature texture data.
          * This is a placeholder for now, but can be used to set the texture data for each planet.
          */
-        for (let i = 0; i < this.settings.numBodies; i++) {
-            for (let j = 0; j < this.settings.numFeatureTexels; j++) {
-                const idx = i * this.settings.numFeatureTexels + j;
-                // Set the data for each planet
-                // For now, we will just set the data to a random value between 0 and 1
-                this.planetFeatureTextureData[idx] = this.rng.getRandomU8();
-            }
+        for (let i = 0; i < 64 * 64 * 4; i++) {
+            this.planetFeatureTextureData[i] = this.rng.getRandomU8();
         }
     }
 

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -15,33 +15,74 @@ export class Universe {
     // Uint8Array and Float32Array are guaranteed to be contiguous in memory, which makes them more performant (cache locality).
     public bodiesActive: Uint8Array;
 
+    /** X positions of all bodies (AU) */
     public positionsX: Float32Array;
+    /** Y positions of all bodies (AU) */
     public positionsY: Float32Array;
+    /** Z positions of all bodies (AU) */
     public positionsZ: Float32Array;
+
+    /** X velocity components of all bodies (AU/year) */
     public velocitiesX: Float32Array;
+    /** Y velocity components of all bodies (AU/year) */
     public velocitiesY: Float32Array;
+    /** Z velocity components of all bodies (AU/year) */
     public velocitiesZ: Float32Array;
+
+    /** X acceleration components of all bodies (AU/year^2) */
     public accelerationsX: Float32Array;
+    /** Y acceleration components of all bodies (AU/year^2) */
     public accelerationsY: Float32Array;
+    /** Z acceleration components of all bodies (AU/year^2) */
     public accelerationsZ: Float32Array;
-    public angularVelocities: Float32Array; // Angular velocities for rotation
+
+    /** Angular velocities (rotation speeds) of all bodies (radians/year) */
+    public angularVelocities: Float32Array;
+    /** Axial tilts of all bodies (radians) */
     public axialTilts: Float32Array;
+
+    /** Masses of all bodies (solar masses) */
     public masses: Float32Array;
+    /** Radii of all bodies (AU) */
     public radii: Float32Array;
+
+    /** Red channels for all bodies' colors (0-1) */
     public colorsR: Float32Array;
+    /** Green channels for all bodies' colors (0-1) */
     public colorsG: Float32Array;
+    /** Blue channels for all bodies' colors (0-1) */
     public colorsB: Float32Array;
+
+    /** The number of bodies that are currently active in the universe. */
     public numActive: number;
+
+    /** Orbital indices of all bodies (index of the body they orbit, -1 if not orbiting) */
     public orbitalIndices: Float32Array;
+    /** Orbital distances of all bodies (distance to the body they orbit, -1 if not orbiting) */
     public orbitalDistances: Float32Array;
+    /** Number of sattelites for each body (number of bodies orbiting this body) */
     public numSattelites: Float32Array;
+
+    /** Array of indices of all stars in the universe */
     public stars: Float32Array;
+    /** The number of stars in the universe */
     public numStars: number;
+
+    /** Temperatures of all bodies (K) */
     public temperatures: Float32Array;
+
+    /** The time elapsed in the universe (years) */
     public timeElapsed: number;
+
+    /** The index of the star in the center of the universe, if applicable */
     public centerStar: number | null;
-    public numFeatureChannels: number;
-    public planetFeatureTextureData: Uint8Array; // Placeholder for planet feature texture data
+
+    /**
+     * The texture data for procedural feature generation.
+     * Each body has a set of texels that can be used to generate features, defined in
+     * the `settings.numFeatureTexels` parameter.
+     * */
+    public planetFeatureTextureData: Uint8Array;
 
     constructor(settings: UniverseSettings) {
         this.settings = settings;
@@ -83,8 +124,8 @@ export class Universe {
         this.timeElapsed = 0;
         this.centerStar = null;
 
-        this.numFeatureChannels = 4;
-        this.planetFeatureTextureData = new Uint8Array(this.settings.numBodies * 4 * this.numFeatureChannels);
+        // Num bodies times number of texels time 4 (RGBA channels)
+        this.planetFeatureTextureData = new Uint8Array(this.settings.numBodies * 4 * this.settings.numFeatureTexels);
 
         this.initialize();
     }
@@ -820,8 +861,8 @@ export class Universe {
          * This is a placeholder for now, but can be used to set the texture data for each planet.
          */
         for (let i = 0; i < this.settings.numBodies; i++) {
-            for (let j = 0; j < this.numFeatureChannels; j++) {
-                const idx = i * this.numFeatureChannels + j;
+            for (let j = 0; j < this.settings.numFeatureTexels; j++) {
+                const idx = i * this.settings.numFeatureTexels + j;
                 // Set the data for each planet
                 // For now, we will just set the data to a random value between 0 and 1
                 this.planetFeatureTextureData[idx] = this.rng.getRandomU8();

--- a/src/lib/webGL/shaderPrograms.tsx
+++ b/src/lib/webGL/shaderPrograms.tsx
@@ -46,6 +46,7 @@ export interface StarlightProgramInfo {
         uNoiseTex: WebGLUniformLocation | null;
         uFeatureTex: WebGLUniformLocation | null;
         uPlanetID: WebGLUniformLocation | null;
+        uNumFeatureSampleTexels: WebGLUniformLocation | null;
     };
 }
 

--- a/src/lib/webGL/shaderPrograms.tsx
+++ b/src/lib/webGL/shaderPrograms.tsx
@@ -44,7 +44,8 @@ export interface StarlightProgramInfo {
         uAngularVelocity: WebGLUniformLocation | null;
         uRotationMultiplier: WebGLUniformLocation | null;
         uNoiseTex: WebGLUniformLocation | null;
-        uNoiseTexSlice: WebGLUniformLocation | null;
+        uFeatureTex: WebGLUniformLocation | null;
+        uPlanetID: WebGLUniformLocation | null;
     };
 }
 

--- a/src/random/RngState.tsx
+++ b/src/random/RngState.tsx
@@ -101,6 +101,14 @@ export class RngState {
         return (this.next() / 0xffffffff) * (max - min) + min;
     }
 
+    /**
+     *
+     * @returns A random number between 0 and 255
+     */
+    public getRandomU8(): number {
+        return this.next() / 0xff;
+    }
+
     public getGaussianF32(mean: number, stdDev: number): number {
         let u1 = this.getRandomF32(0, 1);
         let u2 = this.getRandomF32(0, 1);

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -15,6 +15,7 @@ export interface UniverseSettings {
     rotationMultiplier: number;
     axialTiltMean: number; // Mean axial tilt of the bodies in degrees
     axialTiltStdev: number; // Standard deviation of axial tilt in degrees
+    numFeatureTexels: number; // The number of texels each planet has available to procedurally generate shaders
 }
 
 const initialState: UniverseSettings = {
@@ -30,6 +31,7 @@ const initialState: UniverseSettings = {
     rotationMultiplier: 1, // Multiplier for the rotation speed of bodies, 1.0 means normal speed
     axialTiltMean: Math.PI / 12, // Mean axial tilt of the bodies in degrees
     axialTiltStdev: Math.PI / 9, // Standard deviation of axial tilt in degrees
+    numFeatureTexels: 4,
 };
 
 export const universeSettingsSlice = createSlice({


### PR DESCRIPTION
In this update, I pass in a 64x64 "features" shader. Each planetary body has 4 texels (128 bits) in this texture that they're allowed to sample from. They use those bits to set variables such as noise frequency, noise amplitude, numbands, etc. to give each planet a unique appearance.